### PR TITLE
fix: tolerate multipart/form-data from AQUA wallet

### DIFF
--- a/Plugins/SamRockProtocol/Controllers/ProtocolController.cs
+++ b/Plugins/SamRockProtocol/Controllers/ProtocolController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
@@ -51,7 +52,7 @@ public class ProtocolController(
         if (storeData == null)
             return NotFound(new SamRockProtocolResponse(false, "Store not found.", null));
 
-        var jsonField = Request.Form["json"];
+        var jsonField = await ReadJsonField();
         var setupModel = UtilJson.Parse<SamRockProtocolRequest>(jsonField, out var ex);
         if (setupModel == null)
             return BadRequest(new SamRockProtocolResponse(false, "Invalid JSON format.", ex));
@@ -66,6 +67,74 @@ public class ProtocolController(
         
         logger.LogInformation("SamRockProtocol request initiated. setupModel={SetupModel}", setupModel.ToJson());
         return await processSamRockProtocolRequest(setupModel, storeData, otp);
+    }
+
+    /// <summary>
+    /// Reads the "json" field from the request body, tolerating multiple content types.
+    /// AQUA wallet (Dart/Dio) switched from application/x-www-form-urlencoded to
+    /// multipart/form-data with a malformed boundary prefix, which ASP.NET Core's
+    /// form parser rejects. This method falls back to raw body parsing when that happens.
+    /// </summary>
+    private async Task<string> ReadJsonField()
+    {
+        Request.EnableBuffering();
+
+        try
+        {
+            var formValue = Request.Form["json"].ToString();
+            if (!string.IsNullOrEmpty(formValue))
+                return formValue;
+        }
+        catch (Exception ex)
+        {
+            logger.LogWarning(ex, "Form parsing failed, falling back to raw body parsing");
+        }
+
+        Request.Body.Position = 0;
+        using var reader = new StreamReader(Request.Body, leaveOpen: true);
+        var body = await reader.ReadToEndAsync();
+        if (string.IsNullOrEmpty(body))
+            return null;
+
+        var trimmed = body.Trim();
+
+        // Direct JSON body (application/json)
+        if (trimmed.StartsWith("{"))
+            return trimmed;
+
+        // URL-encoded: json={...}
+        var jsonIdx = body.IndexOf("json=", StringComparison.Ordinal);
+        if (jsonIdx >= 0)
+        {
+            var value = body.Substring(jsonIdx + 5);
+            var ampIdx = value.IndexOf('&');
+            if (ampIdx >= 0)
+                value = value.Substring(0, ampIdx);
+            return Uri.UnescapeDataString(value);
+        }
+
+        // Multipart: extract content after name="json" field header
+        var nameIdx = body.IndexOf("name=\"json\"", StringComparison.Ordinal);
+        if (nameIdx >= 0)
+        {
+            var afterName = body.Substring(nameIdx);
+            var blankLine = afterName.IndexOf("\r\n\r\n", StringComparison.Ordinal);
+            if (blankLine < 0)
+                blankLine = afterName.IndexOf("\n\n", StringComparison.Ordinal);
+            if (blankLine >= 0)
+            {
+                var headerEnd = afterName[blankLine] == '\r' ? blankLine + 4 : blankLine + 2;
+                var content = afterName.Substring(headerEnd);
+                var boundaryIdx = content.IndexOf("\r\n--", StringComparison.Ordinal);
+                if (boundaryIdx < 0)
+                    boundaryIdx = content.IndexOf("\n--", StringComparison.Ordinal);
+                if (boundaryIdx >= 0)
+                    content = content.Substring(0, boundaryIdx);
+                return content.Trim();
+            }
+        }
+
+        return null;
     }
 
     private async Task<IActionResult> processSamRockProtocolRequest(SamRockProtocolRequest setupModel, StoreData storeData, string otp)

--- a/Plugins/SamRockProtocol/SamRockProtocol.csproj
+++ b/Plugins/SamRockProtocol/SamRockProtocol.csproj
@@ -11,7 +11,7 @@
         <Description>Get paid online, receive funds on your phone.
             SamRock Protocol links your store to self-custodial wallet via a simple QR scan. Try it with Aqua Wallet!
         </Description>
-        <Version>1.0.3</Version>
+        <Version>1.0.4</Version>
     </PropertyGroup>
 
     <!-- Plugin development properties -->


### PR DESCRIPTION
## Problem

AQUA wallet's HTTP client (Dart/Dio) switched from sending `application/x-www-form-urlencoded` to `multipart/form-data` for the `/protocol` endpoint. Additionally, Dio sends a malformed boundary in the Content-Type header with a leading `--` prefix (`boundary=--dio-boundary-...`), which ASP.NET Core's form parser rejects outright, returning HTTP 400 before the controller code can read the `json` field.

This was confirmed via pcap analysis: the request reaches BTCPay intact with a valid JSON payload inside the multipart body, but the server responds 400 due to the form parsing failure.

Ref: #7 (related but separate Boltz API issue)

## Fix

Added `ReadJsonField()` to `ProtocolController` that:
1. Enables request buffering upfront so the body can be re-read on fallback
2. Tries `Request.Form["json"]` first (handles standard urlencoded and well-formed multipart)
3. On failure, seeks back to the start of the body and parses it manually:
   - Direct JSON body (`application/json`)
   - URL-encoded `json={...}` field
   - Multipart field extraction (finds `name="json"` header, extracts content between blank line and next boundary)

This makes the server tolerant of whatever Content-Type AQUA sends, without breaking existing clients that use standard form encoding.

Version bumped to 1.0.4.

## Testing

- Existing `application/x-www-form-urlencoded` requests continue to work via `Request.Form["json"]` (no behavior change)
- AQUA's `multipart/form-data` with malformed boundary falls through to raw body parsing, extracts the JSON field correctly
- Direct `application/json` POST is also handled as a bonus