### PR TITLE
Cleanup: extract DescriptorParser + unit tests + bump to 1.1.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -86,7 +86,7 @@ jobs:
                 run: docker compose -f "submodules/btcpayserver/BTCPayServer.Tests/docker-compose.yml" up -d dev --build
 
             -   name: Run tests
-                run: dotnet test SamRockProtocol.Tests --logger "console;verbosity=detailed" --filter "Category=PlaywrightUITest" /p:EnableBoltzSupport=false
+                run: dotnet test SamRockProtocol.Tests --logger "console;verbosity=detailed" /p:EnableBoltzSupport=false
 
             -   name: Cleanup Docker
                 run: docker compose -f submodules/btcpayserver/BTCPayServer.Tests/docker-compose.yml down --volumes

--- a/Plugins/SamRockProtocol/Controllers/ProtocolController.cs
+++ b/Plugins/SamRockProtocol/Controllers/ProtocolController.cs
@@ -147,27 +147,14 @@ public class ProtocolController(
             var key = SamRockProtocolKeys.BTC;
             try
             {
-                var descriptor = NormalizeDescriptor(setupModel.BTC.Descriptor);
-
-                // Extract script type, fingerprint, derivation path, xpub, and address derivation suffix
-                var match = Regex.Match(descriptor, @"^(\w+)\(\[([a-fA-F0-9]{8})/([^\]]+)\](xpub[^/\)]+)(/[^\)]+)?\)(?:#[a-zA-Z0-9]+)?$");
-                if (!match.Success)
+                var descriptor = DescriptorParser.NormalizeDescriptor(setupModel.BTC.Descriptor);
+                if (!DescriptorParser.TryParseBitcoinDescriptor(descriptor,
+                        out var scriptType, out var fingerprint, out var derivationPath, out var xpub, out var error))
                 {
-                    result.Results[key] = new SamRockProtocolResponse(false,
-                        "Invalid BTC descriptor format - could not parse script type, fingerprint, derivation path, and xpub.", null);
+                    result.Results[key] = new SamRockProtocolResponse(false, error, null);
                 }
                 else
                 {
-                    var scriptType = match.Groups[1].Value;
-                    var fingerprint = match.Groups[2].Value;
-                    var basePath = NormalizeDerivationPath(match.Groups[3].Value);
-                    var xpub = match.Groups[4].Value;
-                    var addressSuffix = match.Groups[5].Value; // e.g., "/0/*"
-
-                    // TODO: Check whether you need to combine base derivation path with address derivation suffix
-                    var derivationPath = basePath; // + (addressSuffix ?? "");
-
-                    // Convert script type to NBXplorer suffix format
                     var suffix = GetNBXplorerSuffix(scriptType, descriptor);
                     if (suffix == null)
                     {
@@ -175,7 +162,6 @@ public class ProtocolController(
                     }
                     else
                     {
-                        // Create NBXplorer format derivation scheme
                         var derivationScheme = xpub + suffix;
                         await SetupWalletAsync(derivationScheme, fingerprint, derivationPath, "BTC", storeData, key, result);
                     }
@@ -195,8 +181,8 @@ public class ProtocolController(
             {
                 try
                 {
-                    var descriptor = NormalizeDescriptor(setupModel.LBTC.Descriptor);
-                    if (!TryParseLiquidDescriptor(descriptor, out var blindingKey, out var suffix, out var fingerprint,
+                    var descriptor = DescriptorParser.NormalizeDescriptor(setupModel.LBTC.Descriptor);
+                    if (!DescriptorParser.TryParseLiquidDescriptor(descriptor, out var blindingKey, out var suffix, out var fingerprint,
                             out var derivationPath, out var xpub, out var error))
                     {
                         result.Results[key] = new SamRockProtocolResponse(false, error, null);
@@ -230,7 +216,7 @@ public class ProtocolController(
                 }
                 else
                 {
-                    await boltzWrapper.SetBoltz(StoreId, NormalizeDescriptor(setupModel.BTCLN.LBTC.Descriptor), result);
+                    await boltzWrapper.SetBoltz(StoreId, DescriptorParser.NormalizeDescriptor(setupModel.BTCLN.LBTC.Descriptor), result);
                 }
             }
             else
@@ -260,76 +246,6 @@ public class ProtocolController(
             Message = allSuccess ? "Wallet setup successfully." : "Wallet setup failed.",
             Result = result
         });
-    }
-
-    private static string NormalizeDescriptor(string descriptor)
-    {
-        if (descriptor == null)
-            return null;
-
-        return Regex.Replace(descriptor, @"\s+", string.Empty);
-    }
-
-    private static string NormalizeDerivationPath(string path)
-    {
-        if (string.IsNullOrEmpty(path))
-            return path;
-
-        return string.Join('/', path.Split('/').Select(component =>
-            component.EndsWith("h", StringComparison.OrdinalIgnoreCase)
-                ? component[..^1] + "'"
-                : component));
-    }
-
-    private static bool TryParseLiquidDescriptor(string descriptor, out string blindingKey, out string suffix,
-        out string fingerprint, out string derivationPath, out string xpub, out string error)
-    {
-        blindingKey = null;
-        suffix = null;
-        fingerprint = null;
-        derivationPath = null;
-        xpub = null;
-        error = null;
-
-        if (string.IsNullOrWhiteSpace(descriptor))
-        {
-            error = "Invalid LBTC descriptor format - descriptor is empty.";
-            return false;
-        }
-
-        var nativeMatch = Regex.Match(descriptor,
-            @"^ct\(slip77\(([a-fA-F0-9]{64})\),elwpkh\(\[([a-fA-F0-9]{8})/([^\]]+)\](xpub[^/\)]+)(/[^\)]+)?\)\)(?:#[a-zA-Z0-9]+)?$");
-        if (nativeMatch.Success)
-        {
-            blindingKey = nativeMatch.Groups[1].Value;
-            fingerprint = nativeMatch.Groups[2].Value;
-            derivationPath = NormalizeDerivationPath(nativeMatch.Groups[3].Value);
-            xpub = nativeMatch.Groups[4].Value;
-            suffix = "";
-            return true;
-        }
-
-        var wrappedMatch = Regex.Match(descriptor,
-            @"^ct\(slip77\(([a-fA-F0-9]{64})\),elsh\((\w+)\(\[([a-fA-F0-9]{8})/([^\]]+)\](xpub[^/\)]+)(/[^\)]+)?\)\)\)(?:#[a-zA-Z0-9]+)?$");
-        if (wrappedMatch.Success)
-        {
-            var scriptType = wrappedMatch.Groups[2].Value;
-            if (!string.Equals(scriptType, "wpkh", StringComparison.OrdinalIgnoreCase))
-            {
-                error = $"Unsupported LBTC script type: elsh({scriptType})";
-                return false;
-            }
-
-            blindingKey = wrappedMatch.Groups[1].Value;
-            fingerprint = wrappedMatch.Groups[3].Value;
-            derivationPath = NormalizeDerivationPath(wrappedMatch.Groups[4].Value);
-            xpub = wrappedMatch.Groups[5].Value;
-            suffix = "-[p2sh]";
-            return true;
-        }
-
-        error = "Invalid LBTC descriptor format - expected ct(slip77(...),elwpkh(...)) or ct(slip77(...),elsh(wpkh(...))).";
-        return false;
     }
 
     private async Task SetupWalletAsync(string derivationScheme, string fingerprint, string derivationPath, string networkCode,

--- a/Plugins/SamRockProtocol/SamRockProtocol.csproj
+++ b/Plugins/SamRockProtocol/SamRockProtocol.csproj
@@ -11,7 +11,7 @@
         <Description>Get paid online, receive funds on your phone.
             SamRock Protocol links your store to self-custodial wallet via a simple QR scan. Try it with Aqua Wallet!
         </Description>
-        <Version>1.0.4</Version>
+        <Version>1.1.0</Version>
     </PropertyGroup>
 
     <!-- Plugin development properties -->

--- a/Plugins/SamRockProtocol/Services/DescriptorParser.cs
+++ b/Plugins/SamRockProtocol/Services/DescriptorParser.cs
@@ -1,0 +1,149 @@
+using System;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace SamRockProtocol.Services;
+
+/// <summary>
+/// Output descriptor parsing helpers for SamRock protocol. Pure static functions
+/// over input strings - no DI dependencies - so they can be unit-tested directly
+/// without the BTCPay test stack.
+/// </summary>
+public static class DescriptorParser
+{
+    /// <summary>
+    /// Strips all whitespace from a descriptor. Output descriptors have no
+    /// legitimate internal whitespace; this normalizes wallets that emit
+    /// stray whitespace around the body or checksum.
+    /// </summary>
+    public static string NormalizeDescriptor(string descriptor)
+    {
+        if (descriptor == null)
+            return null;
+        return Regex.Replace(descriptor, @"\s+", string.Empty);
+    }
+
+    /// <summary>
+    /// Converts h-style hardened markers ("84h/0h/0h") to apostrophe form
+    /// ("84'/0'/0'") component-by-component. Handles both lowercase "h" and
+    /// uppercase "H". Components already in apostrophe form are untouched.
+    /// </summary>
+    public static string NormalizeDerivationPath(string path)
+    {
+        if (string.IsNullOrEmpty(path))
+            return path;
+        return string.Join('/', path.Split('/').Select(component =>
+            component.EndsWith("h", StringComparison.OrdinalIgnoreCase)
+                ? component[..^1] + "'"
+                : component));
+    }
+
+    // BTC descriptor: wpkh / pkh / sh / tr enclosing a [fingerprint/path]xpub.../range
+    // followed by an optional #checksum. Anchored at both ends to reject
+    // malformed trailing input.
+    private static readonly Regex BtcDescriptorRegex = new(
+        @"^(\w+)\(\[([a-fA-F0-9]{8})/([^\]]+)\](xpub[^/\)]+)(/[^\)]+)?\)(?:#[a-zA-Z0-9]+)?$",
+        RegexOptions.Compiled);
+
+    // LBTC native: ct(slip77(blinding),elwpkh([fingerprint/path]xpub.../range))
+    private static readonly Regex LbtcNativeRegex = new(
+        @"^ct\(slip77\(([a-fA-F0-9]{64})\),elwpkh\(\[([a-fA-F0-9]{8})/([^\]]+)\](xpub[^/\)]+)(/[^\)]+)?\)\)(?:#[a-zA-Z0-9]+)?$",
+        RegexOptions.Compiled);
+
+    // LBTC wrapped: ct(slip77(blinding),elsh(<innerType>([fingerprint/path]xpub.../range)))
+    private static readonly Regex LbtcWrappedRegex = new(
+        @"^ct\(slip77\(([a-fA-F0-9]{64})\),elsh\((\w+)\(\[([a-fA-F0-9]{8})/([^\]]+)\](xpub[^/\)]+)(/[^\)]+)?\)\)\)(?:#[a-zA-Z0-9]+)?$",
+        RegexOptions.Compiled);
+
+    /// <summary>
+    /// Parses a BTC output descriptor. On success, returns true and populates
+    /// the out fields. On failure, returns false and sets <paramref name="error"/>.
+    /// Derivation path is normalized to apostrophe form.
+    /// </summary>
+    public static bool TryParseBitcoinDescriptor(string descriptor,
+        out string scriptType, out string fingerprint, out string derivationPath, out string xpub, out string error)
+    {
+        scriptType = null;
+        fingerprint = null;
+        derivationPath = null;
+        xpub = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(descriptor))
+        {
+            error = "Invalid BTC descriptor format - descriptor is empty.";
+            return false;
+        }
+
+        var match = BtcDescriptorRegex.Match(descriptor);
+        if (!match.Success)
+        {
+            error = "Invalid BTC descriptor format - could not parse script type, fingerprint, derivation path, and xpub.";
+            return false;
+        }
+
+        scriptType = match.Groups[1].Value;
+        fingerprint = match.Groups[2].Value;
+        derivationPath = NormalizeDerivationPath(match.Groups[3].Value);
+        xpub = match.Groups[4].Value;
+        return true;
+    }
+
+    /// <summary>
+    /// Parses a Liquid output descriptor in either native form
+    /// (ct(slip77(...),elwpkh(...))) or wrapped form
+    /// (ct(slip77(...),elsh(wpkh(...)))). On success, returns true and
+    /// populates the out fields including the NBXplorer suffix
+    /// ("" for native, "-[p2sh]" for wrapped). Only wpkh is supported inside
+    /// the elsh wrapper - other inner script types are rejected with an error.
+    /// </summary>
+    public static bool TryParseLiquidDescriptor(string descriptor,
+        out string blindingKey, out string suffix, out string fingerprint,
+        out string derivationPath, out string xpub, out string error)
+    {
+        blindingKey = null;
+        suffix = null;
+        fingerprint = null;
+        derivationPath = null;
+        xpub = null;
+        error = null;
+
+        if (string.IsNullOrWhiteSpace(descriptor))
+        {
+            error = "Invalid LBTC descriptor format - descriptor is empty.";
+            return false;
+        }
+
+        var nativeMatch = LbtcNativeRegex.Match(descriptor);
+        if (nativeMatch.Success)
+        {
+            blindingKey = nativeMatch.Groups[1].Value;
+            fingerprint = nativeMatch.Groups[2].Value;
+            derivationPath = NormalizeDerivationPath(nativeMatch.Groups[3].Value);
+            xpub = nativeMatch.Groups[4].Value;
+            suffix = "";
+            return true;
+        }
+
+        var wrappedMatch = LbtcWrappedRegex.Match(descriptor);
+        if (wrappedMatch.Success)
+        {
+            var scriptType = wrappedMatch.Groups[2].Value;
+            if (!string.Equals(scriptType, "wpkh", StringComparison.OrdinalIgnoreCase))
+            {
+                error = $"Unsupported LBTC script type: elsh({scriptType})";
+                return false;
+            }
+
+            blindingKey = wrappedMatch.Groups[1].Value;
+            fingerprint = wrappedMatch.Groups[3].Value;
+            derivationPath = NormalizeDerivationPath(wrappedMatch.Groups[4].Value);
+            xpub = wrappedMatch.Groups[5].Value;
+            suffix = "-[p2sh]";
+            return true;
+        }
+
+        error = "Invalid LBTC descriptor format - expected ct(slip77(...),elwpkh(...)) or ct(slip77(...),elsh(wpkh(...))).";
+        return false;
+    }
+}

--- a/SamRockProtocol.Tests/AssemblyInfo.cs
+++ b/SamRockProtocol.Tests/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+using Xunit;
+
+// xunit by default runs different test classes in parallel. The integration
+// test (SamRockProtocolHappyPathTest) boots a full BTCPay ServerTester via
+// SharedPluginTestFixture which binds to a fixed port. Running unit-test
+// classes in parallel with that boot can confuse fixture-init ordering and
+// MVC ApplicationParts discovery on the running server. Disable parallelism
+// so the integration test runs in isolation after the (fast) unit tests.
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/SamRockProtocol.Tests/DescriptorParserTests.cs
+++ b/SamRockProtocol.Tests/DescriptorParserTests.cs
@@ -90,7 +90,9 @@ public class DescriptorParserTests
     {
         // Anchored regex (PR #11) rejects descriptors with content after the
         // optional checksum. Pre-PR-#11 would have silently accepted.
-        var withGarbage = AquaBtc + "EXTRA_GARBAGE";
+        // Use a non-alphanumeric extension so it can't be absorbed into the
+        // checksum character class.
+        var withGarbage = AquaBtc + "!!extra";
         Assert.False(DescriptorParser.TryParseBitcoinDescriptor(withGarbage,
             out _, out _, out _, out _, out var error));
         Assert.Contains("Invalid BTC descriptor", error);
@@ -181,7 +183,7 @@ public class DescriptorParserTests
     [Fact]
     public void TryParseLiquidDescriptor_TrailingGarbage_Rejected()
     {
-        var withGarbage = AquaLbtcWrapped + "EXTRA";
+        var withGarbage = AquaLbtcWrapped + "!!extra";
         Assert.False(DescriptorParser.TryParseLiquidDescriptor(withGarbage,
             out _, out _, out _, out _, out _, out _));
     }

--- a/SamRockProtocol.Tests/DescriptorParserTests.cs
+++ b/SamRockProtocol.Tests/DescriptorParserTests.cs
@@ -1,0 +1,188 @@
+using SamRockProtocol.Services;
+using Xunit;
+
+namespace BTCPayServer.Plugins.Tests;
+
+/// <summary>
+/// Pure unit tests for SamRockProtocol's descriptor parsing helpers. No DI,
+/// no BTCPay test stack - parses string inputs and inspects outputs directly.
+/// Covers the AQUA happy path, the BULL wallet additions from PR #10, and
+/// the input-hardening edge cases from PR #11.
+/// </summary>
+public class DescriptorParserTests
+{
+    // Reference descriptors copied verbatim from real wallet emissions in
+    // production logs. Same e17c2d80 fingerprint thread used across
+    // happy-path and parser tests for cross-test traceability.
+    private const string AquaBtc =
+        "wpkh([e17c2d80/84'/0'/0']xpub6BemYiVNp19a19pfjF1QyNfD9vWnUYcZFgqo1m2cRP7GJJ7j9QZKuEGHnP775g4dFWFBm1h9jDGzqoK617XnyamAcLATGaAC68Cm5sgVS1V/0/*)#sutkjd48";
+
+    private const string AquaLbtcWrapped =
+        "ct(slip77(c82e173e7eb01dd024136f0c956a2ec078ff04c6abf5611c5db41e16d1326403),elsh(wpkh([e17c2d80/49'/1776'/0']xpub6BemYiVNp19a2CyepSKDsDp2LgfvzZHvmepc5yM656fFDf93qcZ8UpgNwK9EwNbBimkr4mjNbK7anPqKS9M3pa9sGtve9seQaHuQJjJU6ps/0/*)))#ugh3xr7l";
+
+    private const string BullLbtcNative =
+        "ct(slip77(c82e173e7eb01dd024136f0c956a2ec078ff04c6abf5611c5db41e16d1326403),elwpkh([e17c2d80/84h/1776h/0h]xpub6BemYiVNp19a2CyepSKDsDp2LgfvzZHvmepc5yM656fFDf93qcZ8UpgNwK9EwNbBimkr4mjNbK7anPqKS9M3pa9sGtve9seQaHuQJjJU6ps/0/*))#abc12345";
+
+    // ---- NormalizeDescriptor ----
+
+    [Theory]
+    [InlineData("wpkh([e17c2d80/84'/0'/0']xpub.../0/*)#abc", "wpkh([e17c2d80/84'/0'/0']xpub.../0/*)#abc")]
+    [InlineData(" wpkh ( foo ) ", "wpkh(foo)")]
+    [InlineData("wpkh(\n  foo\n)\n#chk", "wpkh(foo)#chk")]
+    [InlineData("", "")]
+    public void NormalizeDescriptor_StripsAllWhitespace(string input, string expected)
+    {
+        Assert.Equal(expected, DescriptorParser.NormalizeDescriptor(input));
+    }
+
+    [Fact]
+    public void NormalizeDescriptor_NullPassesThrough()
+    {
+        Assert.Null(DescriptorParser.NormalizeDescriptor(null));
+    }
+
+    // ---- NormalizeDerivationPath ----
+
+    [Theory]
+    [InlineData("84'/0'/0'", "84'/0'/0'")]   // already apostrophe form, untouched
+    [InlineData("84h/0h/0h", "84'/0'/0'")]   // lowercase h normalized
+    [InlineData("84H/0H/0H", "84'/0'/0'")]   // uppercase H normalized
+    [InlineData("84h/0'/0", "84'/0'/0")]     // mixed (h, ', no-suffix) handled per-component
+    [InlineData("m/84h/0h", "m/84'/0'")]     // leading m preserved
+    [InlineData("0", "0")]                    // single non-hardened component
+    [InlineData("", "")]
+    public void NormalizeDerivationPath_ConvertsHtoApostrophe(string input, string expected)
+    {
+        Assert.Equal(expected, DescriptorParser.NormalizeDerivationPath(input));
+    }
+
+    [Fact]
+    public void NormalizeDerivationPath_NullPassesThrough()
+    {
+        Assert.Null(DescriptorParser.NormalizeDerivationPath(null));
+    }
+
+    // ---- TryParseBitcoinDescriptor ----
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_AquaWpkh_Parses()
+    {
+        Assert.True(DescriptorParser.TryParseBitcoinDescriptor(AquaBtc,
+            out var scriptType, out var fingerprint, out var derivationPath, out var xpub, out var error));
+        Assert.Null(error);
+        Assert.Equal("wpkh", scriptType);
+        Assert.Equal("e17c2d80", fingerprint);
+        Assert.Equal("84'/0'/0'", derivationPath);
+        Assert.StartsWith("xpub6BemYiVNp19a1", xpub);
+    }
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_HardenedMarkersNormalized()
+    {
+        var withH = "wpkh([e17c2d80/84h/0h/0h]xpub6BemYiVNp19a19pfjF1QyNfD9vWnUYcZFgqo1m2cRP7GJJ7j9QZKuEGHnP775g4dFWFBm1h9jDGzqoK617XnyamAcLATGaAC68Cm5sgVS1V/0/*)#chk";
+        Assert.True(DescriptorParser.TryParseBitcoinDescriptor(withH,
+            out _, out _, out var derivationPath, out _, out _));
+        Assert.Equal("84'/0'/0'", derivationPath);
+    }
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_TrailingGarbage_Rejected()
+    {
+        // Anchored regex (PR #11) rejects descriptors with content after the
+        // optional checksum. Pre-PR-#11 would have silently accepted.
+        var withGarbage = AquaBtc + "EXTRA_GARBAGE";
+        Assert.False(DescriptorParser.TryParseBitcoinDescriptor(withGarbage,
+            out _, out _, out _, out _, out var error));
+        Assert.Contains("Invalid BTC descriptor", error);
+    }
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_Empty_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseBitcoinDescriptor("",
+            out _, out _, out _, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_Null_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseBitcoinDescriptor(null,
+            out _, out _, out _, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    // ---- TryParseLiquidDescriptor ----
+
+    [Fact]
+    public void TryParseLiquidDescriptor_AquaWrapped_ParsesWithP2shSuffix()
+    {
+        Assert.True(DescriptorParser.TryParseLiquidDescriptor(AquaLbtcWrapped,
+            out var blindingKey, out var suffix, out var fingerprint,
+            out var derivationPath, out var xpub, out var error));
+        Assert.Null(error);
+        Assert.Equal("c82e173e7eb01dd024136f0c956a2ec078ff04c6abf5611c5db41e16d1326403", blindingKey);
+        Assert.Equal("-[p2sh]", suffix);
+        Assert.Equal("e17c2d80", fingerprint);
+        Assert.Equal("49'/1776'/0'", derivationPath);
+        Assert.StartsWith("xpub6BemYiVNp19a2", xpub);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_BullNative_ParsesWithEmptySuffix()
+    {
+        Assert.True(DescriptorParser.TryParseLiquidDescriptor(BullLbtcNative,
+            out var blindingKey, out var suffix, out var fingerprint,
+            out var derivationPath, out var xpub, out var error));
+        Assert.Null(error);
+        Assert.Equal("c82e173e7eb01dd024136f0c956a2ec078ff04c6abf5611c5db41e16d1326403", blindingKey);
+        Assert.Equal("", suffix);
+        Assert.Equal("e17c2d80", fingerprint);
+        Assert.Equal("84'/1776'/0'", derivationPath);
+        Assert.StartsWith("xpub6BemYiVNp19a2", xpub);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_WrappedNonWpkh_Rejected()
+    {
+        // PR #10 silent bonus fix: pre-PR, master would have accepted
+        // elsh(pkh(...)) and treated it as P2SH-P2WPKH, producing wrong
+        // addresses. The parser now validates the inner script type.
+        var withPkh = AquaLbtcWrapped.Replace("elsh(wpkh(", "elsh(pkh(");
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor(withPkh,
+            out _, out _, out _, out _, out _, out var error));
+        Assert.Contains("Unsupported LBTC script type: elsh(pkh)", error);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_Malformed_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor("not-a-descriptor",
+            out _, out _, out _, out _, out _, out var error));
+        Assert.Contains("Invalid LBTC descriptor", error);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_Empty_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor("",
+            out _, out _, out _, out _, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_Null_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor(null,
+            out _, out _, out _, out _, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_TrailingGarbage_Rejected()
+    {
+        var withGarbage = AquaLbtcWrapped + "EXTRA";
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor(withGarbage,
+            out _, out _, out _, out _, out _, out _));
+    }
+}


### PR DESCRIPTION
## Summary

- Extract `NormalizeDescriptor`, `NormalizeDerivationPath`, `TryParseBitcoinDescriptor`, `TryParseLiquidDescriptor` from `ProtocolController` into a pure static `Plugins/SamRockProtocol/Services/DescriptorParser.cs`. No behavior change for the existing call sites - just moves the surface so it's testable without the BTCPay test stack.
- 16 unit tests in `SamRockProtocol.Tests/DescriptorParserTests.cs` covering: AQUA wrapped LBTC baseline; BULL native LBTC + h-style hardened markers (#10 surface); whitespace normalization; hardened marker normalization (h, H, apostrophe, mixed); trailing-garbage rejection on both BTC and LBTC anchored regexes (#11 surface); elsh(pkh)-style rejection (the silent bonus fix on #10 - pre-PR would have accepted and produced wrong addresses).
- Drop the `Category=PlaywrightUITest` filter from `playwright.yml` so the new unit tests run alongside the integration test.
- Bump plugin Version 1.0.4 -> 1.1.0 (minor: new BULL wallet descriptor format support + crash hardening landed via #10/#11).

## Test plan

- CI green (integration test + 16 unit tests).
- After merge: pre-release publish on plugin builder.