### PR TITLE
tests: restore DescriptorParserTests in a separate SamRockProtocol.UnitTests project

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -85,7 +85,14 @@ jobs:
                     COMPOSE_DOCKER_CLI_BUILD: 1
                 run: docker compose -f "submodules/btcpayserver/BTCPayServer.Tests/docker-compose.yml" up -d dev --build
 
-            -   name: Run tests
+            -   name: Run unit tests
+                # Pure-unit-tests project. Runs first because it doesn't need
+                # the BTCPay test stack + Docker - completes in ~1s. Keeps
+                # the unit-test feedback loop fast even when the integration
+                # test below takes minutes.
+                run: dotnet test SamRockProtocol.UnitTests --logger "console;verbosity=normal" /p:EnableBoltzSupport=false
+
+            -   name: Run integration tests
                 run: dotnet test SamRockProtocol.Tests --logger "console;verbosity=detailed" /p:EnableBoltzSupport=false
 
             -   name: Cleanup Docker

--- a/SamRockProtocol.UnitTests/DescriptorParserTests.cs
+++ b/SamRockProtocol.UnitTests/DescriptorParserTests.cs
@@ -1,0 +1,190 @@
+using SamRockProtocol.Services;
+using Xunit;
+
+namespace SamRockProtocol.UnitTests;
+
+/// <summary>
+/// Pure unit tests for SamRockProtocol's descriptor parsing helpers. No DI,
+/// no BTCPay test stack - parses string inputs and inspects outputs directly.
+/// Covers the AQUA happy path, the BULL wallet additions from PR #10, and
+/// the input-hardening edge cases from PR #11.
+/// </summary>
+public class DescriptorParserTests
+{
+    // Reference descriptors copied verbatim from real wallet emissions in
+    // production logs. Same e17c2d80 fingerprint thread used across
+    // happy-path and parser tests for cross-test traceability.
+    private const string AquaBtc =
+        "wpkh([e17c2d80/84'/0'/0']xpub6BemYiVNp19a19pfjF1QyNfD9vWnUYcZFgqo1m2cRP7GJJ7j9QZKuEGHnP775g4dFWFBm1h9jDGzqoK617XnyamAcLATGaAC68Cm5sgVS1V/0/*)#sutkjd48";
+
+    private const string AquaLbtcWrapped =
+        "ct(slip77(c82e173e7eb01dd024136f0c956a2ec078ff04c6abf5611c5db41e16d1326403),elsh(wpkh([e17c2d80/49'/1776'/0']xpub6BemYiVNp19a2CyepSKDsDp2LgfvzZHvmepc5yM656fFDf93qcZ8UpgNwK9EwNbBimkr4mjNbK7anPqKS9M3pa9sGtve9seQaHuQJjJU6ps/0/*)))#ugh3xr7l";
+
+    private const string BullLbtcNative =
+        "ct(slip77(c82e173e7eb01dd024136f0c956a2ec078ff04c6abf5611c5db41e16d1326403),elwpkh([e17c2d80/84h/1776h/0h]xpub6BemYiVNp19a2CyepSKDsDp2LgfvzZHvmepc5yM656fFDf93qcZ8UpgNwK9EwNbBimkr4mjNbK7anPqKS9M3pa9sGtve9seQaHuQJjJU6ps/0/*))#abc12345";
+
+    // ---- NormalizeDescriptor ----
+
+    [Theory]
+    [InlineData("wpkh([e17c2d80/84'/0'/0']xpub.../0/*)#abc", "wpkh([e17c2d80/84'/0'/0']xpub.../0/*)#abc")]
+    [InlineData(" wpkh ( foo ) ", "wpkh(foo)")]
+    [InlineData("wpkh(\n  foo\n)\n#chk", "wpkh(foo)#chk")]
+    [InlineData("", "")]
+    public void NormalizeDescriptor_StripsAllWhitespace(string input, string expected)
+    {
+        Assert.Equal(expected, DescriptorParser.NormalizeDescriptor(input));
+    }
+
+    [Fact]
+    public void NormalizeDescriptor_NullPassesThrough()
+    {
+        Assert.Null(DescriptorParser.NormalizeDescriptor(null));
+    }
+
+    // ---- NormalizeDerivationPath ----
+
+    [Theory]
+    [InlineData("84'/0'/0'", "84'/0'/0'")]   // already apostrophe form, untouched
+    [InlineData("84h/0h/0h", "84'/0'/0'")]   // lowercase h normalized
+    [InlineData("84H/0H/0H", "84'/0'/0'")]   // uppercase H normalized
+    [InlineData("84h/0'/0", "84'/0'/0")]     // mixed (h, ', no-suffix) handled per-component
+    [InlineData("m/84h/0h", "m/84'/0'")]     // leading m preserved
+    [InlineData("0", "0")]                    // single non-hardened component
+    [InlineData("", "")]
+    public void NormalizeDerivationPath_ConvertsHtoApostrophe(string input, string expected)
+    {
+        Assert.Equal(expected, DescriptorParser.NormalizeDerivationPath(input));
+    }
+
+    [Fact]
+    public void NormalizeDerivationPath_NullPassesThrough()
+    {
+        Assert.Null(DescriptorParser.NormalizeDerivationPath(null));
+    }
+
+    // ---- TryParseBitcoinDescriptor ----
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_AquaWpkh_Parses()
+    {
+        Assert.True(DescriptorParser.TryParseBitcoinDescriptor(AquaBtc,
+            out var scriptType, out var fingerprint, out var derivationPath, out var xpub, out var error));
+        Assert.Null(error);
+        Assert.Equal("wpkh", scriptType);
+        Assert.Equal("e17c2d80", fingerprint);
+        Assert.Equal("84'/0'/0'", derivationPath);
+        Assert.StartsWith("xpub6BemYiVNp19a1", xpub);
+    }
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_HardenedMarkersNormalized()
+    {
+        var withH = "wpkh([e17c2d80/84h/0h/0h]xpub6BemYiVNp19a19pfjF1QyNfD9vWnUYcZFgqo1m2cRP7GJJ7j9QZKuEGHnP775g4dFWFBm1h9jDGzqoK617XnyamAcLATGaAC68Cm5sgVS1V/0/*)#chk";
+        Assert.True(DescriptorParser.TryParseBitcoinDescriptor(withH,
+            out _, out _, out var derivationPath, out _, out _));
+        Assert.Equal("84'/0'/0'", derivationPath);
+    }
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_TrailingGarbage_Rejected()
+    {
+        // Anchored regex (PR #11) rejects descriptors with content after the
+        // optional checksum. Pre-PR-#11 would have silently accepted.
+        // Use a non-alphanumeric extension so it can't be absorbed into the
+        // checksum character class.
+        var withGarbage = AquaBtc + "!!extra";
+        Assert.False(DescriptorParser.TryParseBitcoinDescriptor(withGarbage,
+            out _, out _, out _, out _, out var error));
+        Assert.Contains("Invalid BTC descriptor", error);
+    }
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_Empty_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseBitcoinDescriptor("",
+            out _, out _, out _, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryParseBitcoinDescriptor_Null_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseBitcoinDescriptor(null,
+            out _, out _, out _, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    // ---- TryParseLiquidDescriptor ----
+
+    [Fact]
+    public void TryParseLiquidDescriptor_AquaWrapped_ParsesWithP2shSuffix()
+    {
+        Assert.True(DescriptorParser.TryParseLiquidDescriptor(AquaLbtcWrapped,
+            out var blindingKey, out var suffix, out var fingerprint,
+            out var derivationPath, out var xpub, out var error));
+        Assert.Null(error);
+        Assert.Equal("c82e173e7eb01dd024136f0c956a2ec078ff04c6abf5611c5db41e16d1326403", blindingKey);
+        Assert.Equal("-[p2sh]", suffix);
+        Assert.Equal("e17c2d80", fingerprint);
+        Assert.Equal("49'/1776'/0'", derivationPath);
+        Assert.StartsWith("xpub6BemYiVNp19a2", xpub);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_BullNative_ParsesWithEmptySuffix()
+    {
+        Assert.True(DescriptorParser.TryParseLiquidDescriptor(BullLbtcNative,
+            out var blindingKey, out var suffix, out var fingerprint,
+            out var derivationPath, out var xpub, out var error));
+        Assert.Null(error);
+        Assert.Equal("c82e173e7eb01dd024136f0c956a2ec078ff04c6abf5611c5db41e16d1326403", blindingKey);
+        Assert.Equal("", suffix);
+        Assert.Equal("e17c2d80", fingerprint);
+        Assert.Equal("84'/1776'/0'", derivationPath);
+        Assert.StartsWith("xpub6BemYiVNp19a2", xpub);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_WrappedNonWpkh_Rejected()
+    {
+        // PR #10 silent bonus fix: pre-PR, master would have accepted
+        // elsh(pkh(...)) and treated it as P2SH-P2WPKH, producing wrong
+        // addresses. The parser now validates the inner script type.
+        var withPkh = AquaLbtcWrapped.Replace("elsh(wpkh(", "elsh(pkh(");
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor(withPkh,
+            out _, out _, out _, out _, out _, out var error));
+        Assert.Contains("Unsupported LBTC script type: elsh(pkh)", error);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_Malformed_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor("not-a-descriptor",
+            out _, out _, out _, out _, out _, out var error));
+        Assert.Contains("Invalid LBTC descriptor", error);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_Empty_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor("",
+            out _, out _, out _, out _, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_Null_ReturnsError()
+    {
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor(null,
+            out _, out _, out _, out _, out _, out var error));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public void TryParseLiquidDescriptor_TrailingGarbage_Rejected()
+    {
+        var withGarbage = AquaLbtcWrapped + "!!extra";
+        Assert.False(DescriptorParser.TryParseLiquidDescriptor(withGarbage,
+            out _, out _, out _, out _, out _, out _));
+    }
+}

--- a/SamRockProtocol.UnitTests/SamRockProtocol.UnitTests.csproj
+++ b/SamRockProtocol.UnitTests/SamRockProtocol.UnitTests.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+
+        <IsPackable>false</IsPackable>
+        <StaticWebAssetsEnabled>false</StaticWebAssetsEnabled>
+        <RootNamespace>SamRockProtocol.UnitTests</RootNamespace>
+    </PropertyGroup>
+
+    <ItemDefinitionGroup>
+        <ProjectReference>
+            <Properties>StaticWebAssetsEnabled=false</Properties>
+        </ProjectReference>
+    </ItemDefinitionGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+        <PackageReference Include="xunit" Version="2.9.3" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+            <PrivateAssets>all</PrivateAssets>
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+        </PackageReference>
+    </ItemGroup>
+
+    <!--
+        Deliberately references ONLY the SamRockProtocol plugin project, NOT
+        the BTCPayServer test fixtures. The integration-test project
+        (SamRockProtocol.Tests) must stay disentangled from any compile-time
+        reference to plugin-internal types, because BTCPay's PluginManager
+        scans AppDomain.CurrentDomain.GetAssemblies() before its file-based
+        PluginLoader path and dedup-locks out anything already in AppDomain
+        (PluginManager.cs:155-256). A plugin loaded that way registers with
+        Loader=null and skips mvcBuilder.AddPluginLoader, so its controller
+        routes 404 on the integration test. Keeping the pure unit tests in
+        their own assembly lets us cover DescriptorParser without poisoning
+        the integration test.
+    -->
+    <ItemGroup>
+        <ProjectReference Include="..\Plugins\SamRockProtocol\SamRockProtocol.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/SamRockProtocol.sln
+++ b/SamRockProtocol.sln
@@ -35,6 +35,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AResources", "AResources", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SamRockProtocol.Tests", "SamRockProtocol.Tests\SamRockProtocol.Tests.csproj", "{E70B0FF3-63AD-4812-83D2-C83FDC2D95E3}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SamRockProtocol.UnitTests", "SamRockProtocol.UnitTests\SamRockProtocol.UnitTests.csproj", "{9968594F-24FD-4AD0-86F5-E747D10BD468}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -189,6 +191,18 @@ Global
 		{E70B0FF3-63AD-4812-83D2-C83FDC2D95E3}.Release|x64.Build.0 = Release|Any CPU
 		{E70B0FF3-63AD-4812-83D2-C83FDC2D95E3}.Release|x86.ActiveCfg = Release|Any CPU
 		{E70B0FF3-63AD-4812-83D2-C83FDC2D95E3}.Release|x86.Build.0 = Release|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Debug|x64.Build.0 = Debug|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Debug|x86.Build.0 = Debug|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Release|x64.ActiveCfg = Release|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Release|x64.Build.0 = Release|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Release|x86.ActiveCfg = Release|Any CPU
+		{9968594F-24FD-4AD0-86F5-E747D10BD468}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
PR #15 deleted DescriptorParserTests as the structural fix for the master CI route-404. The deletion was the right move (the integration test couldn't co-exist with compile-time refs to plugin-internal types in the same test assembly), but the right SHAPE is to restore the unit tests in a dedicated project rather than lose the coverage.

This PR does that.

## What

- New `SamRockProtocol.UnitTests/SamRockProtocol.UnitTests.csproj` - targets net8.0, references only the SamRockProtocol plugin csproj. NO references to BTCPayServer test fixtures.
- New `SamRockProtocol.UnitTests/DescriptorParserTests.cs` - 16 restored tests from PR #13's original content, namespace renamed to `SamRockProtocol.UnitTests`. 25 distinct test cases when [Theory] parametrizations expand.
- `SamRockProtocol.sln` gets the new project.
- `.github/workflows/playwright.yml` splits the test step into two: unit tests run first (~1s, no Docker required), integration tests run after with the full BTCPay stack. Keeps the fast unit-test feedback loop separate from the heavy ServerTester boot path.

## Why this doesn't re-introduce the route-404 trap

The `SamRockProtocol.Tests` (integration) project stays disentangled - it does not reference this new project, and this new project does not reference any BTCPay test types. The poison-via-AppDomain-load path stays closed:

1. `dotnet test SamRockProtocol.UnitTests` runs in its own test process. The SamRockProtocol assembly loads there. Nothing in BTCPay's PluginManager runs in that process.
2. `dotnet test SamRockProtocol.Tests` runs in a separate test process. SamRockProtocol assembly is NOT loaded into that process's AppDomain (no compile-time refs from the integration test code to plugin-internal services). BTCPay's PluginManager's file-based DEBUG_PLUGINS / plugins-folder path resolves the plugin via PluginLoader, registers MVC parts, and the integration test's plugin routes work.

Master CI run on PR #15's tree was green (run #29 on `df68231`); this PR layers the unit tests back in via a different test process so master stays green.

## Verification

- 25/25 SamRockProtocol.UnitTests passing locally on net8.0.
- Build clean (one pre-existing warning on `DerivationSchemeParser.ParseOutputDescriptor` obsoletion in ProtocolController, unrelated).
- Unit tests run in ~66ms - no Docker, no ServerTester boot.

Follows up Uncle's direction in TG DM 2026-05-26 to keep DescriptorParser unit tests for the static class without the integration-test poisoning.